### PR TITLE
Add input component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blobfish-ui",
-  "version": "1.0.0",
+  "version": "1.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "blobfish-ui",
-      "version": "1.0.0",
+      "version": "1.0.4",
       "license": "ISC",
       "devDependencies": {
         "@types/react": "^18.0.8",
@@ -21,8 +21,8 @@
         "typescript": "^4.6.4"
       },
       "peerDependencies": {
-        "react": "^16.8.0",
-        "react-dom": "^16.8.0"
+        "react": "^17.0.0",
+        "react-dom": "^17.0.0"
       }
     },
     "node_modules/@rollup/pluginutils": {

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+import "./styles.scss"
+
+interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  placeholder: string,
+}
+
+export const Input: React.FC<InputProps> = ({ placeholder, ...props }) => {
+  return (
+    <>
+      <input
+        {...props}
+        type="text"
+        placeholder={placeholder}
+      />
+    </>
+  );
+};
+

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import "./styles.scss"
 
 interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   placeholder: string,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,2 +1,3 @@
 export { SquareButton } from "./components/SquareButton"
 export { RoundButton } from "./components/RoundButton"
+export { Input } from "./components/Input"


### PR DESCRIPTION
Input component added (no styling needed yet). Type defaulted to text for simple and basic usage at, and regular input attributes still able to be used (e.g required, size etc) through extending InputHTMLAttributes. So, if the user wants to use other native DOM attributes they can and it should still work.

- Testing needs to be set-up 
- Further types of input components can be added in the future e.g. radio?
